### PR TITLE
fix usage of class-base routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use ProcessMaker\Package\PackageSkeleton\Http\Controllers\PackageSkeletonController;
+
+
 Route::group(['middleware' => ['auth:api', 'bindings']], function () {
     Route::get('admin/package-skeleton/fetch', [PackageSkeletonController::class, 'fetch'])->name('package.skeleton.fetch');
     Route::apiResource('admin/package-skeleton', PackageSkeletonController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use ProcessMaker\Package\PackageSkeleton\Http\Controllers\PackageSkeletonController;
+
 Route::group(['middleware' => ['auth']], function () {
     Route::get('admin/package-skeleton', [PackageSkeletonController::class, 'index'])->name('package.skeleton.index');
     Route::get('package-skeleton', [PackageSkeletonController::class, 'index'])->name('package.skeleton.tab.index');

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -9,10 +9,7 @@ use ProcessMaker\Package\PackageSkeleton\Listeners\PackageListener;
 
 class PackageServiceProvider extends ServiceProvider
 {
-
-    // Assign the default namespace for our controllers
-    protected $namespace = '\ProcessMaker\Package\PackageSkeleton\Http\Controllers';
-
+    
     /**
      * If your plugin will provide any services, you can register them here.
      * See: https://laravel.com/docs/5.6/providers#the-register-method
@@ -38,12 +35,10 @@ class PackageServiceProvider extends ServiceProvider
             // Assigning to the web middleware will ensure all other middleware assigned to 'web'
             // will execute. If you wish to extend the user interface, you'll use the web middleware
             Route::middleware('web')
-                ->namespace($this->namespace)
                 ->group(__DIR__ . '/../routes/web.php');
 
 
             Route::middleware('api')
-                ->namespace($this->namespace)
                 ->prefix('api/1.0')
                 ->group(__DIR__ . '/../routes/api.php');
 


### PR DESCRIPTION
when we want to use class-base namespace in routes, we should remove the namespace defined in ServiceProvider.

cause it make something like this 

```
use ProcessMaker\Package\PackageSkeleton\Http\Controllers\ProcessMaker\Package\PackageSkeleton\Http\Controllers\PackageSkeletonController;
```

which is incorrect.

there is other things that i saw that can be fixed.